### PR TITLE
feat(js-utilities merge-coverage react-a11y-tools): changed minimum node version to 20 and npm to 10

### DIFF
--- a/.changeset/pink-worms-drum.md
+++ b/.changeset/pink-worms-drum.md
@@ -1,0 +1,7 @@
+---
+"@jtmdias/react-a11y-tools": major
+"@jtmdias/merge-coverage": major
+"@jtmdias/js-utilities": major
+---
+
+Changed minimum node version to 20 and npm to 10 on all packages

--- a/packages/js-utilities/package.json
+++ b/packages/js-utilities/package.json
@@ -5,6 +5,10 @@
 	"version": "2.2.0",
 	"license": "MIT",
 	"type": "module",
+	"engines": {
+		"node": ">= 20",
+		"npm": ">= 10"
+	},
 	"files": [
 		"dist"
 	],

--- a/packages/merge-coverage/package.json
+++ b/packages/merge-coverage/package.json
@@ -4,6 +4,10 @@
   "version": "1.1.1",
   "description": "Merges test coverage between different test frameworks",
   "author": "João Dias",
+  "engines": {
+    "node": ">= 20",
+    "npm": ">= 10"
+  },
   "bin": {
     "merge-coverage": "./bin/run"
   },
@@ -78,9 +82,6 @@
     "version": "oclif readme && git add README.md",
     "prettier:base": "prettier --parser typescript",
     "format:fix": "npm run prettier:base --write '{src,test}/**/*.{ts,tsx,js,jsx}'"
-  },
-  "engines": {
-    "node": ">=20"
   },
   "bugs": "https://github.com/JoaoTMDias/frontend/issues",
   "keywords": [

--- a/packages/react-a11y-tools/package.json
+++ b/packages/react-a11y-tools/package.json
@@ -3,6 +3,10 @@
 	"description": "A small React component library that aims to ease the process of creating accessible design systems, web apps or websites",
 	"private": false,
 	"version": "2.0.0",
+	"engines": {
+		"node": ">= 20",
+		"npm": ">= 10"
+	},
 	"author": {
 		"name": "João Dias",
 		"url": "https://joaodias.me"
@@ -21,10 +25,6 @@
 	"files": [
 		"dist"
 	],
-	"engine": {
-		"node": ">= 18",
-		"npm": ">= 10"
-	},
 	"scripts": {
 		"types:check": "tsc --project ./tsconfig.json --noEmit",
 		"build": "npm run types:check && vite build",


### PR DESCRIPTION
Sets the minimum version of node to 20 and npm to 10.
This might be a breaking change for those that still use old node versions.